### PR TITLE
Improve performance for CSV generation

### DIFF
--- a/src/commonMain/kotlin/Csv.kt
+++ b/src/commonMain/kotlin/Csv.kt
@@ -8,17 +8,18 @@ public class Csv(
     public fun toCsvText(
         newLine: NewLine = NewLine.LF,
         escapeWhitespaces: Boolean = false,
-    ): String =
-        rows.fold("") { acc, row ->
-            val rowText =
-                row
-                    .fold("") { rowAcc, value ->
-                        val escapedValue = value.escapeCsvValue(escapeWhitespaces)
-                        "$rowAcc$escapedValue,"
-                    }
-                    .removeSuffix(",")
-            "$acc$rowText${newLine.value}"
+    ): String = buildString {
+        rows.forEach { row ->
+            row.forEachIndexed { index, value ->
+                val escapedValue = value.escapeCsvValue(escapeWhitespaces)
+                append(escapedValue)
+                if (index < (row.size - 1)) {
+                    append(',')
+                }
+            }
+            append(newLine.value)
         }
+    }
 }
 
 public enum class NewLine(


### PR DESCRIPTION
This change results in a huge performance improvement on `toCsvText` for larger output sizes.

The performance boost comes from using a string builder instead of concatenating the strings one by one, which gets slower as the output size gets bigger.
With this change the generation time becomes O(n).

I didn't write a performance test for this, but testing locally on a CSV file of around 500kB the generation time went from many seconds (10s+) to less than a second.

Thanks for sharing this implementation.