### PR TITLE
Add DataRow.replaceValue() and ability to create CSV from lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # 🗂 CSV ️
 
-Small, fast and convenient multplatform CSV parser and builder written for one of my projects, and then shared with awesome Kotlin community.
+Small, fast and convenient multiplatform CSV parser and builder written for one of my projects, and then shared with awesome Kotlin community.
 
-![Architecture diagram](https://www.plantuml.com/plantuml/svg/VP7BQkim48RtUeh1Avz5p3bRSt02oQA5q4AJNUb2aIQEY2v66kT2stUl8ijre51lFFppVtCPBG9nJxtHB1oLxRZd1ZekZhp53LqrWaT1tBOQsK5913GTNS6WsQ4FWnG8FJgwTjaYb1VHpeJc8S0odE2TGVmEo2Nw6XxI_yMTvqcMd7WDQnNe_og6KM-IJYwYMxnG-QU63NbbM_QPgqurScrb9LwUzqkdUsDBomsEJ8GVBKraxf6v4zSzbY9XJ_VK6CmdCb8vIiCE-OQnV2uejgwRQJoXXdrl1IbdGv7x35onwvMMSQrojLd75Z4gW0SOvNjhntt0cpKFDBd7p6soaOJgLJeYb6zLaqvUG-UTx0K6bls_UjXqq9bNxO5c7qrQU3nNN6p_BIP1khEDGZe6kvLpWmJ5twhwLqnFz2DfY_4L65kWbRtHNm00)
+![Architecture diagram](https://www.plantuml.com/plantuml/svg/VP9FQnin4CNl-XJ3dZPGB-tLb2KaERGGMgXBBwM7YJHUY-ZF8it6CMs_U-LPRJQqnRvO-_IRDuyPNMV6n9DtAZ_QC6923oFgHnnenoT7a4WpXi6HEbX3G7xa4tZo3vJoB6McH95FOqMqJRhWIZlC6Mumqsr-WfyAoW-T-nAFUGltDlFxSkn5vbYGh_JCxTKMTfni6DJlnM6jFX0QIblu8F-bMbI3ZDNmhXp5T2bUqMfXWw7dp_lRw2OVse2UIiUFWTUAwb7v9tGJjLhmJqBNV7ARQ7IewTjVq1i8T1InuDLlRL0-waaoptQzKdNiqDnCrXbAkQaPPhXvECjb6EtTxlwg0SomAA-fyjcDc3B9E6VpcHRrF_G-HNzEabl9ypfKFrTMGeQqz8JkkudCP7vqlQne2sEAPjAKLUrqaLayBp5gtTucsU70cr-zZ6_PqSRH_aKKmSHZE0iIjzYjXSjB53NE83Hlk-vTixwIVov3yx90TKt1JDxz0G00)
 
 # Usage
 
@@ -24,7 +24,7 @@ val csv = buildCsv {
     }
     row {
         value("BY")
-        value("BELARUS")
+        value("Belarus")
     }
 }
 
@@ -32,7 +32,7 @@ val csv = buildCsv {
 val csvText = csv.toCsvText()
 
 // Parse CSV text to get a CSV object
-val csv2 = parseCsv(csvText)
+val csv2 = Csv.parseText(csvText)
 
 // Data structure
 val allRows: List<Row> = csv2.rows
@@ -40,8 +40,8 @@ val header: HeaderRow? = csv2.header
 val data: List<DataRow> = csv2.data
 
 // Transform CSV
-val codes = data.mapNotNull { it.value("Code") } // ["DE", "BY"]
-val names = data.mapNotNull { it.value("Name") } // ["Germany", "Belarus"]
+val codes = data.map { it.value("Code") } // ["DE", "BY"]
+val names = data.map { it.value("Name") } // ["Germany", "Belarus"]
 ```
 
 Feel free to open PRs for features you miss, please remember keeping API minimalistic, predictable and self-explanatory.
@@ -52,7 +52,7 @@ In `gradle/libs.versions.toml`
 ```toml
 [versions]
 kotlin = "2.0.20"
-csv = "0.12"
+csv = "0.13"
 
 [libraries]
 csv = { module = "de.halfbit:csv", version.ref = "csv" }
@@ -83,6 +83,7 @@ kotlin {
 
 # Release Notes
 
+- 0.13  See PR #13 for details.
 - 0.12 Add HeaderRow and DataRow types, enabling easier data transformations
 - 0.11 Update to Kotlin 2.0.20
 - 0.10 Migrate to the Apache 2.0 license

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "de.halfbit"
-version = "0.12"
+version = "0.13"
 
 repositories {
     mavenCentral()

--- a/documentation/architecture.iuml
+++ b/documentation/architecture.iuml
@@ -4,34 +4,42 @@ hide empty members
 hide stereotype
 hide circle
 
-class Csv {
-    header: HeaderRow?
-    data: List<DataRow>
+class BaseCsv {
+    allRows: List<Row>
     toCsvText(): String
 }
 
+class Csv {
+    header: HeaderRow
+    data: List<DataRow>
+}
+
 class HeaderRow {
-    indexOfColumn(name: String): Int
+    indexOfColumn(name): Int
 }
 
 class DataRow {
-    value(columnName: String): String?
+    value(columnName): String
+    replaceValue(columnName, newValue): DataRow
 }
 
 class Row
 class List<String>
 
-package "Top-level functions" {
-    class "buildCsv(DSL): Csv" as buildCsv
-    class "parseCsv(String): Csv" as parseCsv
+package "Builders" {
+    class "buildCsv(DSL)" as buildCsv
+    class "Csv.parseText(String)" as parseCsv
+    class "Csv.fromLists(List<List<String>>)" as fromList
 }
 
 buildCsv .[dotted].> Csv : produces
 parseCsv .[dotted].> Csv : produces
+fromList .[dotted].> Csv : produces
 
 HeaderRow -right-|> Row
 DataRow -left-|> Row
 Row -down-|> List
+Csv -right-|> BaseCsv
 Csv o-down- "0..1" HeaderRow
 Csv o-down- "0..n" DataRow
 

--- a/src/commonMain/kotlin/Csv.kt
+++ b/src/commonMain/kotlin/Csv.kt
@@ -47,7 +47,7 @@ public interface Csv : BaseCsv {
     }
 
     public interface DataRow : Row {
-        public fun value(columnName: String): String?
+        public fun value(columnName: String): String
         public fun replaceValue(columnName: String, newValue: String): DataRow
     }
 

--- a/src/commonMain/kotlin/Csv.kt
+++ b/src/commonMain/kotlin/Csv.kt
@@ -52,13 +52,13 @@ public interface Csv : BaseCsv {
     }
 
     public companion object {
-        public fun fromText(csvText: String): Csv = parseCsv(csvText)
+        public fun parserText(csvText: String): Csv = parseCsv(csvText)
 
-        public fun fromList(allRows: List<List<String>>): BaseCsv {
+        public fun fromLists(allRows: List<List<String>>): BaseCsv {
             return BaseCsv(allRows.map { DefaultRow(it) })
         }
 
-        public fun fromList(header: List<String>, data: List<List<String>>): Csv {
+        public fun fromLists(header: List<String>, data: List<List<String>>): Csv {
             val headerRow = DefaultHeaderRow(header)
             return Csv(
                 header = headerRow,

--- a/src/commonMain/kotlin/buildCsv.kt
+++ b/src/commonMain/kotlin/buildCsv.kt
@@ -118,14 +118,14 @@ internal class DefaultDataRow(
         row.getOrNull(header.indexOfColumn(columnName))
 
     override fun replaceValue(columnName: String, newValue: String): DataRow {
-        val thisRow = this
         val replaceIndex = header.indexOfColumn(columnName)
+        if (replaceIndex < 0) return this
         val newRow = buildList {
-            for (index in 0..max(thisRow.size, replaceIndex)) {
+            for (index in 0..max(row.lastIndex, replaceIndex)) {
                 if (index == replaceIndex) {
                     add(newValue)
                 } else {
-                    add(thisRow.getOrNull(index) ?: "")
+                    add(row.getOrNull(index) ?: "")
                 }
             }
         }

--- a/src/commonMain/kotlin/buildCsv.kt
+++ b/src/commonMain/kotlin/buildCsv.kt
@@ -114,8 +114,8 @@ internal class DefaultDataRow(
     private val header: HeaderRow
 ) : DataRow, DefaultRow(row) {
 
-    override fun value(columnName: String): String? =
-        row.getOrNull(header.indexOfColumn(columnName))
+    override fun value(columnName: String): String =
+        row.getOrNull(header.indexOfColumn(columnName)) ?: ""
 
     override fun replaceValue(columnName: String, newValue: String): DataRow {
         val replaceIndex = header.indexOfColumn(columnName)

--- a/src/commonMain/kotlin/parseCsv.kt
+++ b/src/commonMain/kotlin/parseCsv.kt
@@ -78,18 +78,15 @@ internal fun parseCsv(csvText: String): Csv {
                             BeforeValue
                         }
                         '\r' -> {
+                            pos++
                             when (nextChar()) {
                                 '\n' -> {
                                     pos++
-                                    InsideValue
-                                }
-                                else -> {
-                                    pos++
-                                    completeValue()
-                                    completeRow()
-                                    BeforeValue
                                 }
                             }
+                            completeValue()
+                            completeRow()
+                            BeforeValue
                         }
                         '\n' -> {
                             pos++

--- a/src/commonMain/kotlin/parseCsv.kt
+++ b/src/commonMain/kotlin/parseCsv.kt
@@ -5,7 +5,7 @@ import de.halfbit.csv.Csv.DataRow
 import de.halfbit.csv.Csv.HeaderRow
 import de.halfbit.csv.Lexer.*
 
-public fun parseCsv(csvText: String): Csv {
+internal fun parseCsv(csvText: String): Csv {
     var pos = 0
     var lexer: Lexer = BeforeValue
 
@@ -26,9 +26,9 @@ public fun parseCsv(csvText: String): Csv {
 
     fun completeRow() {
         if (header.isEmpty()) {
-            header += HeaderRow(row.toList())
+            header += DefaultHeaderRow(row.toList())
         } else {
-            data += DataRow(row.toList(), header[0])
+            data += DefaultDataRow(row.toList(), header[0])
         }
         row.clear()
     }
@@ -137,7 +137,8 @@ public fun parseCsv(csvText: String): Csv {
         pos++
     }
 
-    return Csv(header.getOrNull(0), data)
+    val headerRow = header.getOrNull(0) ?: DefaultHeaderRow(emptyList())
+    return Csv(headerRow, data)
 }
 
 private enum class Lexer {

--- a/src/commonTest/kotlin/BuildCsvTest.kt
+++ b/src/commonTest/kotlin/BuildCsvTest.kt
@@ -37,17 +37,17 @@ class BuildCsvTest {
         assertEquals(header.indexOf("DESCRIPTION"), 2)
 
         assertEquals(csv.data.size, 3)
-        assertEquals(csv.data[0].value("NAME"), "BEVERLY HILLS BLACK")
-        assertEquals(csv.data[0].value("CODE"), "BVH.1-NAR.S8")
-        assertEquals(csv.data[0].value("DESCRIPTION"), null)
+        assertEquals("BEVERLY HILLS BLACK", csv.data[0].value("NAME"))
+        assertEquals("BVH.1-NAR.S8", csv.data[0].value("CODE"))
+        assertEquals("", csv.data[0].value("DESCRIPTION"))
 
-        assertEquals(csv.data[1].value("NAME"), "BOAVISTA BLACK GRADIENT")
-        assertEquals(csv.data[1].value("CODE"), "BVS.1-NAR.S5")
-        assertEquals(csv.data[1].value("DESCRIPTION"), "")
+        assertEquals("BOAVISTA BLACK GRADIENT", csv.data[1].value("NAME"))
+        assertEquals("BVS.1-NAR.S5", csv.data[1].value("CODE"))
+        assertEquals("", csv.data[1].value("DESCRIPTION"))
 
-        assertEquals(csv.data[2].value("NAME"), "GXP EYEWEAR PACKAGING")
-        assertEquals(csv.data[2].value("CODE"), "PKG.2")
-        assertEquals(csv.data[2].value("DESCRIPTION"), "PU pouch for eyewear in black cardboard box")
+        assertEquals("GXP EYEWEAR PACKAGING", csv.data[2].value("NAME"))
+        assertEquals("PKG.2", csv.data[2].value("CODE"))
+        assertEquals("PU pouch for eyewear in black cardboard box", csv.data[2].value("DESCRIPTION"))
     }
 
     @Test
@@ -75,10 +75,11 @@ class BuildCsvTest {
             }
         }
 
-        val descriptions = csv.data.mapNotNull {
+        val descriptions = csv.data.map {
             it.value("DESCRIPTION")
         }
 
-        assertEquals(listOf("", "PU pouch for eyewear in black cardboard box"), descriptions)
+        val expectedDescriptions = listOf("", "", "PU pouch for eyewear in black cardboard box")
+        assertEquals(expectedDescriptions, descriptions)
     }
 }

--- a/src/commonTest/kotlin/CsvTest.kt
+++ b/src/commonTest/kotlin/CsvTest.kt
@@ -67,7 +67,7 @@ class CsvTest {
                 .replace("\n", "\r\n")
 
         val csv = parseCsv(givenCsvString)
-        val header = csv.rows[0]
+        val header = csv.allRows[0]
 
         val nameIndex = header.indexOf("NAME")
         assertEquals(0, nameIndex)

--- a/src/commonTest/kotlin/CsvTest.kt
+++ b/src/commonTest/kotlin/CsvTest.kt
@@ -69,6 +69,9 @@ class CsvTest {
         val csv = parseCsv(givenCsvString)
         val header = csv.allRows[0]
 
+        println(csv.toCsvText())
+        assertEquals(3, csv.allRows.size)
+
         val nameIndex = header.indexOf("NAME")
         assertEquals(0, nameIndex)
 

--- a/src/commonTest/kotlin/Issue1Test.kt
+++ b/src/commonTest/kotlin/Issue1Test.kt
@@ -18,7 +18,7 @@ class Issue1Test {
             """.trimIndent()
 
         val csv = parseCsv(givenCsvString)
-        assertEquals(3, csv.rows.size)
-        assertContentEquals(listOf("1999", "Chevy", "Venture", ""), csv.rows[2])
+        assertEquals(3, csv.allRows.size)
+        assertContentEquals(listOf("1999", "Chevy", "Venture", ""), csv.allRows[2])
     }
 }

--- a/src/commonTest/kotlin/ReplaceValueTest.kt
+++ b/src/commonTest/kotlin/ReplaceValueTest.kt
@@ -38,7 +38,7 @@ class ReplaceValueTest {
 }
 
 private val Csv.DataRow.code: String
-    get() = value("CODE") ?: ""
+    get() = value("CODE")
 
 private val Csv.DataRow.description: String
-    get() = value("DESCRIPTION") ?: ""
+    get() = value("DESCRIPTION")

--- a/src/commonTest/kotlin/ReplaceValueTest.kt
+++ b/src/commonTest/kotlin/ReplaceValueTest.kt
@@ -1,0 +1,41 @@
+package de.halfbit.csv
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReplaceValueTest {
+
+    @Test
+    fun replaceValue() {
+
+        val givenCsvString =
+            """
+                NAME,CODE,DESCRIPTION
+                BURGUNDY PINK,4PK.GD-S7,Pink burgundy
+                HILLS PINK,BVH.5-NAR.S8,Pink hills
+                PACKAGING,PKG.1,"Models: A, B, C"
+            """.trimIndent()
+
+        val csv = Csv.fromText(givenCsvString)
+        val data = csv.data
+            .map {
+                val code = it.code
+                if (!code.startsWith("PKG.")) {
+                    it.replaceValue("DESCRIPTION", "")
+                } else it
+            }
+
+        val csv2 = Csv(csv.header, data)
+        println(csv2)
+
+        assertEquals("", csv2.data[0].description)
+        assertEquals("", csv2.data[1].description)
+        assertEquals("Models: A, B, C", csv2.data[2].description)
+    }
+}
+
+private val Csv.DataRow.code: String
+    get() = value("CODE") ?: ""
+
+private val Csv.DataRow.description: String
+    get() = value("DESCRIPTION") ?: ""

--- a/src/commonTest/kotlin/ReplaceValueTest.kt
+++ b/src/commonTest/kotlin/ReplaceValueTest.kt
@@ -10,10 +10,13 @@ class ReplaceValueTest {
 
         val givenCsvString =
             """
-                NAME,CODE,DESCRIPTION
-                BURGUNDY PINK,4PK.GD-S7,Pink burgundy
-                HILLS PINK,BVH.5-NAR.S8,Pink hills
-                PACKAGING,PKG.1,"Models: A, B, C"
+                NAME,CODE,PRICE,DESCRIPTION
+                BURGUNDY PINK,4PK.GD-S7,100,Pink burgundy
+                HILLS PINK,BVH.5-NAR.S8,120Pink hills
+                PACKAGING,PKG.1,0.55,Eyewear packages. Models: all
+                DARK BLUE,EVG.6,101,"Matte stainless steel. 
+                Line 2.
+                Line 3"
             """.trimIndent()
 
         val csv = Csv.parserText(givenCsvString)
@@ -26,11 +29,11 @@ class ReplaceValueTest {
             }
 
         val csv2 = Csv(csv.header, data)
-        println(csv2)
+        println(csv2.toCsvText())
 
         assertEquals("", csv2.data[0].description)
         assertEquals("", csv2.data[1].description)
-        assertEquals("Models: A, B, C", csv2.data[2].description)
+        assertEquals("Eyewear packages. Models: all", csv2.data[2].description)
     }
 }
 

--- a/src/commonTest/kotlin/ReplaceValueTest.kt
+++ b/src/commonTest/kotlin/ReplaceValueTest.kt
@@ -16,7 +16,7 @@ class ReplaceValueTest {
                 PACKAGING,PKG.1,"Models: A, B, C"
             """.trimIndent()
 
-        val csv = Csv.fromText(givenCsvString)
+        val csv = Csv.parserText(givenCsvString)
         val data = csv.data
             .map {
                 val code = it.code


### PR DESCRIPTION
I. New method for replacing values in a Csv-object:

`val newData = csv.data.map { it.replaceValue("DESCRIPTION", "") }`

II. API has slightly changed. Minor code update is needed:

1. `parseCsv()` → `Csv.parseText()`
2. `Csv.rows` → `Csv.allRows`

III. Fixes #11 `Csv.fromLists()` can create Csv-object from lists of strings.
