### PR TITLE
Add macosArm64 target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
     linuxArm64()
     mingwX64()
     macosX64()
+    macosArm64()
     js {
         browser {
             testTask {


### PR DESCRIPTION
Adds `macosArm64()` to `build.gradle.kts` to build and publish artifacts for macOS ARM64.